### PR TITLE
Changed the files further so they would generate Cache

### DIFF
--- a/StarCombinator.Examples.fst
+++ b/StarCombinator.Examples.fst
@@ -58,20 +58,37 @@ let rec tiny' () = (
 )
 let tiny = make (tiny' ())
 
-let main0 () =
+val mi_line_non_empty : unit -> FStar.All.ML (option (s : string{String.length s > 0}))
+let mi_line_non_empty () =
   let prog = mi_input_line () in
+  if String.length prog > 0
+  then Some prog
+  else None
+
+
+let main0 () =
+  let prog = mi_line_non_empty () in
+  match prog with
+  | None -> ()
+  | Some prog ->
   mi_print_string (match tiny prog with
     | Inl x -> "Youpi:" ^ x
     | Inr x -> x)
 
 let main1 () =
-  let prog = mi_input_line () in
-  mi_print_string (match calculator prog with
-    | r -> r)
+  let prog = mi_line_non_empty () in
+  match prog with
+  | None -> ()
+  | Some prog ->
+    mi_print_string (match calculator prog with
+      | r -> r)
 
 
 let main2 () =
-  let prog = mi_input_line () in
+  let prog = mi_line_non_empty () in
+  match prog with
+  | None -> ()
+  | Some prog ->
   mi_print_string (match (make (match_list "("
                                            ")"
                                            (exact_char ',')
@@ -81,7 +98,10 @@ let main2 () =
 
 
 let main3 () =
-  let prog = mi_input_line () in
+  let prog = mi_line_non_empty () in
+  match prog with
+  | None -> ()
+  | Some prog ->
   mi_print_string (match (make ((
                hFunction @<< (
                    (keyword "function" <*>> word)
@@ -93,7 +113,10 @@ let main3 () =
 
 
 let main4 () =
-  let prog = mi_input_line () in
+  let prog = mi_line_non_empty () in
+  match prog with
+  | None -> ()
+  | Some prog ->
   mi_print_string (match (make (lFakeInstr_parser <<*> eof)) prog with
     | Inl r -> lFakeInstrToString r
     | Inr r -> r)


### PR DESCRIPTION
It seems that my PR from last time wasn't completely correct (F* mode fooled me by showing an improper verification!).

However, I have since ran my [cache script](https://github.com/mariari/Misc-Lisp-Scripts/blob/master/cache-fstar-source.lisp) on examples and core, and they properly produce a .cached now.


It seems inner lets do not work properly for SMT inlining in F*, so a lot of those calls had to be changed.

Note there is one small hack that I've added
```fstar
position = min (max s1.maximum_position s2.maximum_position) (f s1.position s2.position)
```
in `(+++)`, this was to quickly get the relation that position <= max_position